### PR TITLE
Redesign popup card layout and score display

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -264,7 +264,7 @@ const CSS_TEXT = `
 /* ===== Popup Card ===== */
 .wg-popup-card {
   position: absolute;
-  width: 360px;
+  width: 520px;
   max-height: 520px;
   background:
     radial-gradient(circle at top right, rgba(255, 219, 188, 0.28), transparent 28%),
@@ -305,15 +305,6 @@ const CSS_TEXT = `
   gap: 3px;
 }
 
-.wg-popup-kicker {
-  font-family: var(--wg-font-body);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--wg-accent-strong);
-}
-
 .wg-popup-title {
   font-family: var(--wg-font-display);
   font-size: 17px;
@@ -349,7 +340,6 @@ const CSS_TEXT = `
 
 .wg-popup-body {
   padding: 16px;
-  max-height: 380px;
   overflow-y: auto;
 }
 
@@ -392,39 +382,10 @@ const CSS_TEXT = `
   color: var(--wg-text-secondary);
 }
 
-.wg-pill-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 12px;
-}
-
-.wg-pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 5px 10px;
-  border-radius: 999px;
-  background: var(--wg-pill-bg);
-  border: 1px solid var(--wg-border-soft);
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--wg-accent-soft);
-  letter-spacing: 0.01em;
-}
-
 .wg-popup-actions {
   display: flex;
   gap: 8px;
   padding: 12px 16px 14px;
-  border-top: 1px solid var(--wg-border-soft);
-  background: var(--wg-bg-soft);
-}
-
-.wg-popup-footer {
-  padding: 10px 16px 12px;
-  text-align: center;
-  font-size: 11px;
-  color: var(--wg-text-tertiary);
   border-top: 1px solid var(--wg-border-soft);
   background: var(--wg-bg-soft);
 }
@@ -469,9 +430,11 @@ const CSS_TEXT = `
 
 /* ===== Score Display ===== */
 .wg-score-display {
-  text-align: center;
-  margin-bottom: 12px;
-  padding: 14px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 10px;
+  padding: 10px 14px;
   border-radius: 16px;
   background: var(--wg-surface-raised);
   border: 1px solid var(--wg-border-soft);
@@ -479,9 +442,10 @@ const CSS_TEXT = `
 
 .wg-gauge-wrap {
   position: relative;
-  width: 90px;
-  height: 90px;
-  margin: 0 auto 8px;
+  width: 56px;
+  height: 56px;
+  margin: 0;
+  flex-shrink: 0;
 }
 
 .wg-gauge {
@@ -493,13 +457,13 @@ const CSS_TEXT = `
 .wg-gauge-bg {
   fill: none;
   stroke: var(--wg-gauge-track);
-  stroke-width: 8;
+  stroke-width: 6;
 }
 
 .wg-gauge-fill {
   fill: none;
   stroke: #4ECDC4;
-  stroke-width: 8;
+  stroke-width: 6;
   stroke-linecap: round;
   stroke-dasharray: 314;
   stroke-dashoffset: 314;
@@ -507,26 +471,23 @@ const CSS_TEXT = `
 }
 
 .wg-score-number {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   font-family: var(--wg-font-display);
-  font-size: 28px;
+  font-size: 22px;
   font-weight: 700;
   font-variation-settings: "opsz" 48, "SOFT" 50, "WONK" 1;
   font-feature-settings: "tnum" 1;
   color: var(--wg-text);
   letter-spacing: -0.02em;
+  line-height: 1;
 }
 
 .wg-tier-label {
   font-family: var(--wg-font-display);
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 700;
   font-variation-settings: "opsz" 24, "SOFT" 60, "WONK" 1;
   letter-spacing: -0.005em;
+  margin-left: auto;
 }
 
 /* ===== Loading ===== */

--- a/src/content/popup-card.ts
+++ b/src/content/popup-card.ts
@@ -6,7 +6,7 @@ import { LoadingState } from "./loading-state";
 import { DiffView } from "./diff-view";
 import { ToneSelector } from "./tone-selector";
 
-const POPUP_WIDTH = 360;
+const POPUP_WIDTH = 520;
 const POPUP_MAX_HEIGHT = 520;
 const POPUP_GAP = 8;
 const VIEWPORT_PADDING = 8;
@@ -17,7 +17,6 @@ export class PopupCard {
   private headerEl: HTMLElement;
   private bodyEl: HTMLElement;
   private actionsEl: HTMLElement;
-  private footerEl: HTMLElement;
   private emptyStateEl: HTMLElement;
   private scoreDisplay: ScoreDisplay;
   private loadingState: LoadingState;
@@ -46,7 +45,6 @@ export class PopupCard {
     this.headerEl.className = "wg-popup-header";
     this.headerEl.innerHTML = `
       <div class="wg-popup-heading">
-        <span class="wg-popup-kicker">On-device writing assist</span>
         <span class="wg-popup-title">WriteGooderer</span>
       </div>
       <button class="wg-close-btn" aria-label="Close WriteGooderer">&times;</button>
@@ -66,11 +64,6 @@ export class PopupCard {
       <p class="wg-empty-copy">
         Grammar, spelling, punctuation, and punchier rewrites without sending your text to a cloud API.
       </p>
-      <div class="wg-pill-row">
-        <span class="wg-pill">Grammar + clarity</span>
-        <span class="wg-pill">Tone presets</span>
-        <span class="wg-pill">Local only</span>
-      </div>
     `;
 
     // Score display
@@ -117,15 +110,9 @@ export class PopupCard {
     this.actionsEl.appendChild(proofreadBtn);
     this.actionsEl.appendChild(toneBtn);
 
-    // Footer
-    this.footerEl = document.createElement("div");
-    this.footerEl.className = "wg-popup-footer";
-    this.footerEl.textContent = "Chrome Prompt API · local only";
-
     this.el.appendChild(this.headerEl);
     this.el.appendChild(this.bodyEl);
     this.el.appendChild(this.actionsEl);
-    this.el.appendChild(this.footerEl);
 
     shadowRoot.appendChild(this.el);
   }
@@ -172,7 +159,6 @@ export class PopupCard {
     const chromeHeight =
       this.headerEl.offsetHeight +
       this.actionsEl.offsetHeight +
-      this.footerEl.offsetHeight +
       2;
     const popupMaxHeight = Math.max(
       chromeHeight + MIN_BODY_HEIGHT,

--- a/src/content/score-display.ts
+++ b/src/content/score-display.ts
@@ -34,20 +34,20 @@ export class ScoreDisplay {
     svg.appendChild(bgCircle);
     svg.appendChild(this.gaugeCircle);
 
-    // Score number overlay
-    this.scoreText = document.createElement("span");
-    this.scoreText.className = "wg-score-number";
-
     const gaugeWrap = document.createElement("div");
     gaugeWrap.className = "wg-gauge-wrap";
     gaugeWrap.appendChild(svg);
-    gaugeWrap.appendChild(this.scoreText);
+
+    // Score number (sibling of the gauge, inline)
+    this.scoreText = document.createElement("span");
+    this.scoreText.className = "wg-score-number";
 
     // Tier label
     this.tierLabel = document.createElement("div");
     this.tierLabel.className = "wg-tier-label";
 
     this.el.appendChild(gaugeWrap);
+    this.el.appendChild(this.scoreText);
     this.el.appendChild(this.tierLabel);
   }
 


### PR DESCRIPTION
## Summary
This PR redesigns the WriteGooderer popup card with a wider layout and restructured score display. The changes focus on improving the visual hierarchy and space utilization of the popup interface.

## Key Changes

- **Increased popup width** from 360px to 520px to accommodate a horizontal score display layout
- **Removed UI elements**: Eliminated the kicker text ("On-device writing assist"), pill badges (Grammar + clarity, Tone presets, Local only), and footer section to simplify the interface
- **Redesigned score display** from a centered vertical layout to a horizontal flex layout with:
  - Reduced gauge size from 90px to 56px
  - Score number repositioned as a sibling element instead of an overlay
  - Tier label moved to the right with `margin-left: auto`
  - Adjusted padding and spacing for the new layout
- **Removed max-height constraint** from popup body to allow more flexible content sizing
- **Updated gauge styling**: Reduced stroke width from 8 to 6 for the smaller gauge
- **Adjusted typography**: Reduced score number font size from 28px to 22px and tier label from 15px to 14px

## Implementation Details

The score display now uses a horizontal flexbox layout (`display: flex; gap: 14px`) instead of a centered text-based design. The gauge and score number are positioned side-by-side with the tier label aligned to the right, creating a more compact and information-dense header for the popup card.

https://claude.ai/code/session_01KAK7ZWyQiH4TuxLvGEG1QR