### PR TITLE
Add MIT license, contributing guide, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report something that isn't working
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Environment**
+- Chrome version:
+- OS:
+- Prompt API available (yes/no):
+- Gemini Nano model downloaded (yes/no):
+
+**Where it happened**
+- Site / URL (if public):
+- Field type (textarea, contenteditable, compose box, etc.):
+
+**Steps to reproduce**
+1.
+2.
+3.
+
+**Expected behavior**
+
+**Actual behavior**
+
+**Console output**
+Paste any relevant errors from the page console or the extension service worker console.
+
+**Screenshots**
+If applicable.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for WriteGooderer
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Problem**
+What are you trying to do that's awkward or impossible today?
+
+**Proposed solution**
+What would you like to see?
+
+**Alternatives considered**
+Other approaches you thought about and why they're not as good.
+
+**Scope**
+Which part of the extension would this touch?
+- [ ] Popup
+- [ ] Content script (in-page UI)
+- [ ] Background service worker
+- [ ] Shared logic / prompts
+- [ ] Other:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,24 @@
+# Code of Conduct
+
+## Our pledge
+
+We want WriteGooderer to be a welcoming project for everyone, regardless of background or experience level.
+
+## Expected behavior
+
+- Be respectful and constructive in issues, PRs, and discussions
+- Assume good faith
+- Focus feedback on the code and ideas, not the person
+- Help newcomers when you can
+
+## Unacceptable behavior
+
+- Personal attacks, harassment, or discriminatory language
+- Posting others' private information without permission
+- Sustained disruption of discussions
+
+## Enforcement
+
+Report concerns to **victorhuangwq@gmail.com**. Reports will be reviewed and acted on as needed, which may include warnings, removing comments, or banning contributors from the project.
+
+This Code of Conduct applies to all project spaces — issues, pull requests, discussions, and any other channels associated with the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to WriteGooderer
+
+Thanks for your interest in improving WriteGooderer.
+
+## Prerequisites
+
+- Node.js (LTS)
+- Chrome `138+` with the Prompt API enabled and Gemini Nano downloaded (see [README](README.md#requirements))
+
+## Setup
+
+```bash
+npm install
+npm run build
+```
+
+Then load the unpacked extension from `dist/` via `chrome://extensions` (Developer Mode → Load unpacked).
+
+## Development loop
+
+```bash
+npm run typecheck
+npm run test          # unit tests
+npm run test:e2e      # end-to-end tests via the demo page
+```
+
+`demo.html` is a local page for exercising textareas, contenteditable editors, and compose boxes.
+
+## Pull requests
+
+- Target `main`
+- Keep PRs focused — one concern per PR
+- Add or update tests for new logic in `src/shared/` and `src/content/`
+- Run `npm run typecheck` and `npm run test` before pushing
+- Match the existing commit style: short imperative subjects (see `git log`)
+
+## Reporting bugs
+
+Open an issue using the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md). Include your Chrome version, whether the Prompt API is available, and console output if relevant.
+
+## Feature requests
+
+Use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Victor Huang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ npm run test:e2e
 
 `demo.html` is included as a local page for exercising supported fields like textareas, contenteditable editors, and compose boxes.
 
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and PR guidelines, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community expectations.
+
 ## How It Works
 
 - `src/content/` injects the floating button and in-page card UI
@@ -84,3 +88,7 @@ Unit tests cover storage, prompts, constants, and field detection logic. End-to-
 - This is a Manifest V3 extension
 - It does not run on special Chrome pages like `chrome://...`
 - Site-level enable/disable state is stored in `chrome.storage.local`
+
+## License
+
+Released under the [MIT License](LICENSE).


### PR DESCRIPTION
Adds standard GitHub project hygiene: MIT LICENSE, CONTRIBUTING.md with setup and PR guidelines, a short CODE_OF_CONDUCT.md, and bug report / feature request issue templates. README gains Contributing and License sections; structure otherwise unchanged.