### PR TITLE
Rewrite README with more voice and drop duplicated build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,93 +1,58 @@
 # WriteGooderer
 
-WriteGooderer is a Chrome extension that proofreads and rewrites text directly inside webpages using Chrome's built-in on-device AI.
+WriteGooderer is a Chrome extension that proofreads and rewrites text in the page you're already typing in. It runs on Chrome's built-in, on-device AI — nothing you write leaves the browser.
 
-It adds a floating `W` button to supported text fields, scores your writing, suggests corrections, and can rewrite selected text in preset tones like Professional, Friendly, LinkedIn Influencer, or Passive Aggressive.
+Click into a text field, a floating `W` appears, and from there you can catch typos, score how the sentence is landing, or swap the whole thing into a different tone without tabbing away.
 
 ## What It Does
 
-- Proofreads text for grammar, spelling, punctuation, and clarity
-- Assigns a "Gooderness" score from `0` to `100`
-- Shows inline diff-style corrections before you apply them
-- Rewrites text in multiple tones without leaving the page
-- Stores preferences locally, including last-used tone and disabled sites
+- Catches grammar, spelling, punctuation, and clarity slips
+- Assigns a Gooderness score from `0` to `100`
+- Shows inline, diff-style corrections before anything gets applied
+- Rewrites selections in preset tones: Professional, Friendly, LinkedIn Influencer, Passive Aggressive
+- Remembers your last tone and any sites you've muted it on
 - Runs fully on-device through Chrome's Prompt API
 
 ## Requirements
 
 - Chrome `138+`
-- A Chrome build with the Prompt API available
-- The Gemini Nano model downloaded in Chrome
+- A Chrome build that ships the Prompt API
+- The Gemini Nano model downloaded locally
 
-If the popup says the Prompt API is unavailable:
+If the popup tells you the Prompt API is unavailable:
 
 1. Open `chrome://flags`
 2. Enable `Prompt API for Gemini Nano`
 3. Open `chrome://components`
-4. Update the on-device model component if Chrome has not already fetched it
-
-## Local Development
-
-Install dependencies:
-
-```bash
-npm install
-```
-
-Build the extension:
-
-```bash
-npm run build
-```
-
-Load it in Chrome:
-
-1. Open `chrome://extensions`
-2. Enable Developer Mode
-3. Click `Load unpacked`
-4. Select the repo's `dist/` directory
-
-## Development Commands
-
-```bash
-npm run build
-npm run typecheck
-npm run test
-npm run test:e2e
-```
-
-`demo.html` is included as a local page for exercising supported fields like textareas, contenteditable editors, and compose boxes.
-
-## Contributing
-
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and PR guidelines, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community expectations.
+4. Update the on-device model if Chrome hasn't already pulled it down
 
 ## How It Works
 
-- `src/content/` injects the floating button and in-page card UI
-- `src/popup/` contains the extension action popup
-- `src/background/` hosts the MV3 service worker
-- `src/shared/` holds prompts, storage helpers, types, and score/tone constants
-- `simple-chromium-ai` manages Prompt API sessions and structured responses
+The heavy lifting on top of the Prompt API is done by [`simple-chromium-ai`](https://www.npmjs.com/package/simple-chromium-ai), which handles session creation, cloning, and structured JSON responses so the extension can stay focused on UI and prompts. Sessions are prewarmed, cloned per request, and destroyed once the proofread or rewrite is done — fast to respond, nothing lingering in memory.
 
-The content script prewarms cached AI sessions, clones them per request, and destroys clones after each proofread or rewrite. That keeps interactions faster without keeping request state around longer than needed.
+The rest of the code is organized like this:
 
-## Testing
+- `src/content/` — the floating button and the in-page card UI
+- `src/popup/` — the extension action popup
+- `src/background/` — the MV3 service worker
+- `src/shared/` — prompts, storage helpers, types, and score/tone constants
 
-Unit tests cover storage, prompts, constants, and field detection logic. End-to-end tests exercise the extension behavior through the demo page and mock AI mode.
+## Using it
 
-## Current UX
+1. Click into a supported field; the floating `W` shows up
+2. Open the card to proofread or pick a tone
+3. Look over the diff or the rewritten version
+4. Apply it back into the field
 
-- Click into a supported field to reveal the floating `W`
-- Open the card to proofread or switch tone
-- Review the diff or rewritten output
-- Apply the result back into the field
+## Contributing
+
+Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, dev commands, and PR guidelines, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community expectations.
 
 ## Notes
 
-- This is a Manifest V3 extension
-- It does not run on special Chrome pages like `chrome://...`
-- Site-level enable/disable state is stored in `chrome.storage.local`
+- Manifest V3 extension
+- Does not run on `chrome://...` pages — Chrome won't let it, and fair enough
+- Per-site enable/disable state lives in `chrome.storage.local`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,6 @@ The rest of the code is organized like this:
 
 Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, dev commands, and PR guidelines, and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community expectations.
 
-## Notes
-
-- Manifest V3 extension
-- Does not run on `chrome://...` pages — Chrome won't let it, and fair enough
-- Per-site enable/disable state lives in `chrome.storage.local`
-
 ## License
 
 Released under the [MIT License](LICENSE).


### PR DESCRIPTION
Dev setup and build commands already live in CONTRIBUTING.md, so the README no longer repeats them. Also credits simple-chromium-ai for the Prompt API session handling, and tightens the overall tone.