### PR TITLE
Speculatively warm the model with the paragraph while the user decides

### DIFF
--- a/src/content/ai-client.ts
+++ b/src/content/ai-client.ts
@@ -3,19 +3,28 @@ import type { ChromiumAIInstance } from "simple-chromium-ai";
 import type { ProofreadResult, RewriteResult, TonePreset } from "../shared/types";
 import { getTierForScore } from "../shared/constants";
 import {
-  PROOFREAD_INITIAL_PROMPTS,
+  DUAL_INITIAL_PROMPTS,
   PROOFREAD_SCHEMA,
-  TONE_INITIAL_PROMPTS,
   TONE_REWRITE_SCHEMA,
-  buildTonePrompt,
+  buildProofreadInstruction,
+  buildRewriteInstruction,
+  buildWarmupPrompt,
 } from "../shared/prompts";
+
+const WARMUP_MAX_CHARS = 1500;
 
 let aiInstance: ChromiumAIInstance | null = null;
 let testMode = false;
 type AISession = Awaited<ReturnType<typeof ChromiumAI.createSession>>;
 
-let proofreadBaseSessionPromise: Promise<AISession> | null = null;
-let toneBaseSessionPromise: Promise<AISession> | null = null;
+let dualBaseSessionPromise: Promise<AISession> | null = null;
+
+export type WarmClone = {
+  session: AISession;
+  warmup: Promise<void>;
+  text: string;
+  dispose: () => void;
+};
 
 function logSessionEvent(message: string): void {
   console.debug(`[WriteGooderer AI] ${message}`);
@@ -33,95 +42,98 @@ async function ensureModel(): Promise<ChromiumAIInstance> {
   return aiInstance;
 }
 
-async function createBaseSession(
-  kind: "proofread" | "tone",
-  initialPrompts: typeof PROOFREAD_INITIAL_PROMPTS
-): Promise<AISession> {
-  logSessionEvent(`Creating base ${kind} session`);
+async function createDualBaseSession(): Promise<AISession> {
+  logSessionEvent("Creating dual base session");
   const ai = await ensureModel();
   const session = await ChromiumAI.createSession(ai, {
-    initialPrompts: initialPrompts as any,
+    initialPrompts: DUAL_INITIAL_PROMPTS as any,
   });
-  logSessionEvent(`Created base ${kind} session`);
+  logSessionEvent("Created dual base session");
   return session;
 }
 
-function getBaseSessionPromise(kind: "proofread" | "tone"): Promise<AISession> {
-  const existingPromise =
-    kind === "proofread" ? proofreadBaseSessionPromise : toneBaseSessionPromise;
-  if (existingPromise) return existingPromise;
+function getDualBaseSessionPromise(): Promise<AISession> {
+  if (dualBaseSessionPromise) return dualBaseSessionPromise;
 
-  const initialPrompts =
-    kind === "proofread" ? PROOFREAD_INITIAL_PROMPTS : TONE_INITIAL_PROMPTS;
-
-  const sessionPromise = createBaseSession(kind, initialPrompts).catch((error) => {
-    logSessionEvent(`Base ${kind} session creation failed: ${String(error)}`);
-    if (kind === "proofread") {
-      proofreadBaseSessionPromise = null;
-    } else {
-      toneBaseSessionPromise = null;
-    }
+  const sessionPromise = createDualBaseSession().catch((error) => {
+    logSessionEvent(`Dual base session creation failed: ${String(error)}`);
+    dualBaseSessionPromise = null;
     throw error;
   });
 
-  if (kind === "proofread") {
-    proofreadBaseSessionPromise = sessionPromise;
-  } else {
-    toneBaseSessionPromise = sessionPromise;
-  }
-
+  dualBaseSessionPromise = sessionPromise;
   return sessionPromise;
 }
 
-async function cloneSession(kind: "proofread" | "tone"): Promise<AISession> {
+async function cloneDualSession(): Promise<AISession> {
   try {
-    const baseSession = await getBaseSessionPromise(kind);
-    logSessionEvent(`Cloning ${kind} session`);
+    const baseSession = await getDualBaseSessionPromise();
+    logSessionEvent("Cloning dual session");
     const clonedSession = await baseSession.clone();
-    logSessionEvent(`Cloned ${kind} session`);
+    logSessionEvent("Cloned dual session");
     return clonedSession;
   } catch (error) {
-    logSessionEvent(`Clone failed for ${kind}, rebuilding base session: ${String(error)}`);
-    if (kind === "proofread") {
-      proofreadBaseSessionPromise = null;
-    } else {
-      toneBaseSessionPromise = null;
-    }
-
-    const rebuiltSession = await getBaseSessionPromise(kind);
+    logSessionEvent(`Clone failed, rebuilding dual base session: ${String(error)}`);
+    dualBaseSessionPromise = null;
+    const rebuiltSession = await getDualBaseSessionPromise();
     const clonedSession = await rebuiltSession.clone();
-    logSessionEvent(`Rebuilt and cloned ${kind} session`);
+    logSessionEvent("Rebuilt and cloned dual session");
     return clonedSession;
   }
 }
 
 export async function prewarmSessions(): Promise<void> {
   if (testMode) return;
-
-  logSessionEvent("Prewarming proofread and tone base sessions");
-  await Promise.all([
-    getBaseSessionPromise("proofread"),
-    getBaseSessionPromise("tone"),
-  ]);
-  logSessionEvent("Prewarmed proofread and tone base sessions");
+  logSessionEvent("Prewarming dual base session");
+  await getDualBaseSessionPromise();
+  logSessionEvent("Prewarmed dual base session");
 }
 
 export async function destroySessions(): Promise<void> {
-  logSessionEvent("Destroying cached base sessions");
-  const sessions = await Promise.allSettled([
-    proofreadBaseSessionPromise,
-    toneBaseSessionPromise,
-  ]);
-
-  for (const result of sessions) {
-    if (result.status === "fulfilled" && result.value) {
-      result.value.destroy();
+  logSessionEvent("Destroying cached base session");
+  const result = await Promise.allSettled([dualBaseSessionPromise]);
+  for (const r of result) {
+    if (r.status === "fulfilled" && r.value) {
+      r.value.destroy();
     }
   }
+  dualBaseSessionPromise = null;
+  logSessionEvent("Destroyed cached base session");
+}
 
-  proofreadBaseSessionPromise = null;
-  toneBaseSessionPromise = null;
-  logSessionEvent("Destroyed cached base sessions");
+export function canWarmText(text: string): boolean {
+  if (testMode) return false;
+  const trimmed = text.trim();
+  return trimmed.length > 0 && trimmed.length <= WARMUP_MAX_CHARS;
+}
+
+export async function warmCloneForText(text: string): Promise<WarmClone> {
+  const session = await cloneDualSession();
+  let disposed = false;
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    try {
+      session.destroy();
+      logSessionEvent("Disposed warm clone");
+    } catch (err) {
+      logSessionEvent(`Warm clone dispose failed: ${String(err)}`);
+    }
+  };
+
+  logSessionEvent("Warm clone: prompting paragraph");
+  const warmup = session
+    .prompt(buildWarmupPrompt(text))
+    .then(() => {
+      logSessionEvent("Warm clone: paragraph ingested");
+    })
+    .catch((err: unknown) => {
+      logSessionEvent(`Warm clone prompt failed: ${String(err)}`);
+      throw err;
+    });
+
+  return { session, warmup, text, dispose };
 }
 
 function mockProofread(text: string): ProofreadResult {
@@ -153,33 +165,73 @@ function mockRewrite(text: string, tone: string): RewriteResult {
   return { rewritten: `[${tone.toUpperCase()}] ${text}` };
 }
 
-export async function proofread(text: string): Promise<ProofreadResult> {
-  if (testMode) return mockProofread(text);
-  const session = await cloneSession("proofread");
+export async function finalizeProofread(warm: WarmClone): Promise<ProofreadResult> {
   try {
-    logSessionEvent("Running proofread prompt");
-    const raw = await session.prompt(text, {
+    logSessionEvent("Finalize proofread: awaiting warmup");
+    await warm.warmup;
+    logSessionEvent("Finalize proofread: running instruction");
+    const raw = await warm.session.prompt(buildProofreadInstruction(), {
       responseConstraint: PROOFREAD_SCHEMA,
     });
     return JSON.parse(raw) as ProofreadResult;
   } finally {
-    logSessionEvent("Destroying proofread clone");
-    session.destroy();
+    warm.dispose();
+  }
+}
+
+export async function finalizeRewrite(
+  warm: WarmClone,
+  tone: TonePreset
+): Promise<RewriteResult> {
+  try {
+    logSessionEvent("Finalize rewrite: awaiting warmup");
+    await warm.warmup;
+    logSessionEvent(`Finalize rewrite: running instruction for ${tone}`);
+    const raw = await warm.session.prompt(buildRewriteInstruction(tone), {
+      responseConstraint: TONE_REWRITE_SCHEMA,
+    });
+    return JSON.parse(raw) as RewriteResult;
+  } finally {
+    warm.dispose();
+  }
+}
+
+export async function proofread(text: string): Promise<ProofreadResult> {
+  if (testMode) return mockProofread(text);
+  try {
+    const warm = await warmCloneForText(text);
+    return await finalizeProofread(warm);
+  } catch (err) {
+    logSessionEvent(`Proofread wrapper failed, falling back: ${String(err)}`);
+    const session = await cloneDualSession();
+    try {
+      const raw = await session.prompt(
+        `${buildWarmupPrompt(text)}\n\n${buildProofreadInstruction()}`,
+        { responseConstraint: PROOFREAD_SCHEMA }
+      );
+      return JSON.parse(raw) as ProofreadResult;
+    } finally {
+      session.destroy();
+    }
   }
 }
 
 export async function rewrite(text: string, tone: TonePreset): Promise<RewriteResult> {
   if (testMode) return mockRewrite(text, tone);
-  const session = await cloneSession("tone");
   try {
-    const prompt = buildTonePrompt(text, tone);
-    logSessionEvent(`Running tone rewrite prompt for ${tone}`);
-    const raw = await session.prompt(prompt, {
-      responseConstraint: TONE_REWRITE_SCHEMA,
-    });
-    return JSON.parse(raw) as RewriteResult;
-  } finally {
-    logSessionEvent("Destroying tone clone");
-    session.destroy();
+    const warm = await warmCloneForText(text);
+    return await finalizeRewrite(warm, tone);
+  } catch (err) {
+    logSessionEvent(`Rewrite wrapper failed, falling back: ${String(err)}`);
+    const session = await cloneDualSession();
+    try {
+      const raw = await session.prompt(
+        `${buildWarmupPrompt(text)}\n\n${buildRewriteInstruction(tone)}`,
+        { responseConstraint: TONE_REWRITE_SCHEMA }
+      );
+      return JSON.parse(raw) as RewriteResult;
+    } finally {
+      session.destroy();
+    }
   }
 }

--- a/src/content/popup-card.ts
+++ b/src/content/popup-card.ts
@@ -1,4 +1,12 @@
-import { proofread, rewrite } from "./ai-client";
+import {
+  canWarmText,
+  finalizeProofread,
+  finalizeRewrite,
+  proofread,
+  rewrite,
+  warmCloneForText,
+  type WarmClone,
+} from "./ai-client";
 import { getTierForScore } from "../shared/constants";
 import type { TonePreset } from "../shared/types";
 import { ScoreDisplay } from "./score-display";
@@ -25,6 +33,7 @@ export class PopupCard {
 
   private activeField: HTMLElement | null = null;
   private repositionRAF: number | null = null;
+  private pendingWarm: WarmClone | null = null;
   private onLoadingChange: (loading: boolean) => void;
   private onScoreReady: (field: HTMLElement, score: number, color: string) => void;
 
@@ -109,6 +118,7 @@ export class PopupCard {
     this.el.classList.add("wg-visible");
     this.attachToField(field);
     this.startTracking();
+    this.kickoffWarmup(field);
   }
 
   attachToField(field: HTMLElement): void {
@@ -116,6 +126,7 @@ export class PopupCard {
     this.activeField = field;
 
     if (changedField) {
+      this.disposePendingWarm();
       this.resetContent();
     }
 
@@ -125,7 +136,43 @@ export class PopupCard {
   hide(): void {
     this.el.classList.remove("wg-visible");
     this.stopTracking();
+    this.disposePendingWarm();
     this.resetContent();
+  }
+
+  private disposePendingWarm(): void {
+    if (this.pendingWarm) {
+      this.pendingWarm.dispose();
+      this.pendingWarm = null;
+    }
+  }
+
+  private kickoffWarmup(field: HTMLElement): void {
+    const text = this.getFieldText(field);
+    if (!canWarmText(text)) return;
+    this.disposePendingWarm();
+    warmCloneForText(text)
+      .then((warm) => {
+        if (this.activeField !== field || this.getFieldText(field) !== text) {
+          warm.dispose();
+          return;
+        }
+        this.pendingWarm = warm;
+      })
+      .catch(() => {
+        // swallow — finalize path will fall back to a fresh session
+      });
+  }
+
+  private takeWarmFor(text: string): WarmClone | null {
+    const warm = this.pendingWarm;
+    if (!warm) return null;
+    if (warm.text !== text) {
+      this.disposePendingWarm();
+      return null;
+    }
+    this.pendingWarm = null;
+    return warm;
   }
 
   get isVisible(): boolean {
@@ -220,7 +267,8 @@ export class PopupCard {
     this.rewriteResult.style.display = "none";
 
     try {
-      const result = await proofread(text);
+      const warm = this.takeWarmFor(text);
+      const result = warm ? await finalizeProofread(warm) : await proofread(text);
 
       const tier = getTierForScore(result.score);
       if (requestField) {
@@ -258,7 +306,8 @@ export class PopupCard {
     this.rewriteResult.style.display = "none";
 
     try {
-      const result = await rewrite(text, tone);
+      const warm = this.takeWarmFor(text);
+      const result = warm ? await finalizeRewrite(warm, tone) : await rewrite(text, tone);
 
       if (!requestField || this.activeField !== requestField) {
         return;

--- a/src/shared/prompts.ts
+++ b/src/shared/prompts.ts
@@ -105,3 +105,76 @@ export function buildTonePrompt(text: string, tone: TonePreset): string {
   const config = TONES[tone];
   return `Tone: ${config.name} (${config.description})\n\nText: ${text}`;
 }
+
+export const DUAL_SYSTEM_PROMPT =
+  "You are WriteGooderer. You handle two tasks on user text: (a) proofread — return corrections, a 0-100 quality score, and a tier name; (b) rewrite in a specified tone — preserve meaning, commit fully to the tone. The user will first share a paragraph; acknowledge briefly with the single word READY and wait. When the user then asks you to proofread or rewrite, respond only with JSON matching the requested schema. Honest scoring: perfect text 90+, minor issues 60-80, significant issues below 50.";
+
+export const DUAL_INITIAL_PROMPTS: (
+  | { role: "system"; content: string }
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string }
+)[] = [
+  { role: "system", content: DUAL_SYSTEM_PROMPT },
+  {
+    role: "user",
+    content:
+      "Paragraph:\n\nI has went to the stor yesterday and buyed some mik.",
+  },
+  { role: "assistant", content: "READY" },
+  {
+    role: "user",
+    content: "Now proofread the paragraph above.",
+  },
+  {
+    role: "assistant",
+    content: JSON.stringify({
+      corrected: "I went to the store yesterday and bought some milk.",
+      changes: [
+        {
+          original: "has went",
+          replacement: "went",
+          reason: "Incorrect auxiliary verb",
+        },
+        { original: "stor", replacement: "store", reason: "Spelling" },
+        {
+          original: "buyed",
+          replacement: "bought",
+          reason: "Irregular past tense",
+        },
+        { original: "mik", replacement: "milk", reason: "Spelling" },
+      ],
+      score: 18,
+      tier: "Caveman",
+    }),
+  },
+  {
+    role: "user",
+    content: "Paragraph:\n\nI got promoted at work today.",
+  },
+  { role: "assistant", content: "READY" },
+  {
+    role: "user",
+    content:
+      "Now rewrite the paragraph above in this tone: LinkedIn Influencer (performative self-help hustle energy).",
+  },
+  {
+    role: "assistant",
+    content: JSON.stringify({
+      rewritten:
+        "I'm thrilled to announce that after years of dedication, countless late nights, and unwavering belief in myself...\n\nI got a promotion.\n\nBut this isn't about the title. It's about the JOURNEY.\n\nHere are 3 lessons I learned along the way:\n\n1. Show up every day\n2. Be authentic\n3. Never stop grinding\n\nAgree? \u{1F447}",
+    }),
+  },
+];
+
+export function buildWarmupPrompt(text: string): string {
+  return `Paragraph:\n\n${text}`;
+}
+
+export function buildProofreadInstruction(): string {
+  return "Now proofread the paragraph above.";
+}
+
+export function buildRewriteInstruction(tone: TonePreset): string {
+  const config = TONES[tone];
+  return `Now rewrite the paragraph above in this tone: ${config.name} (${config.description}).`;
+}


### PR DESCRIPTION
Collapse the proofread and tone base sessions into a single dual-duty session whose system prompt and few-shots cover both tasks. When the popup opens over a field with text, clone that session and send the paragraph as a warmup turn — so by the time the user clicks Proofread or a tone, only a short action instruction plus the schema-constrained generation remains. Falls back cleanly if the field text drifts, the warmup fails, or test mode is on.