### PR TITLE
Replace warmup pattern with clone pool + hover speculation

### DIFF
--- a/e2e/extension.test.ts
+++ b/e2e/extension.test.ts
@@ -198,7 +198,7 @@ describe("WriteGooderer E2E", () => {
       expect(popupVisible).toBe(false);
     });
 
-    it("assigns unique ids to textareas and moves the popup when focus changes", async () => {
+    it("assigns unique ids to textareas and closes the popup when focus changes", async () => {
       await openPopupOnTextareaIndex(page, 0);
 
       const before = await page.evaluate(() => {
@@ -210,10 +210,11 @@ describe("WriteGooderer E2E", () => {
         return {
           firstId: textareas[0]?.getAttribute("data-wg-field-id"),
           secondId: textareas[1]?.getAttribute("data-wg-field-id"),
-          popupTop: popup?.style.top ?? null,
-          popupLeft: popup?.style.left ?? null,
+          popupVisible: popup?.classList.contains("wg-visible") ?? false,
         };
       });
+
+      expect(before.popupVisible).toBe(true);
 
       await clickTextareaByIndex(page, 1);
 
@@ -226,8 +227,7 @@ describe("WriteGooderer E2E", () => {
         return {
           firstId: textareas[0]?.getAttribute("data-wg-field-id"),
           secondId: textareas[1]?.getAttribute("data-wg-field-id"),
-          popupTop: popup?.style.top ?? null,
-          popupLeft: popup?.style.left ?? null,
+          popupVisible: popup?.classList.contains("wg-visible") ?? false,
         };
       });
 
@@ -236,9 +236,7 @@ describe("WriteGooderer E2E", () => {
       expect(before.firstId).not.toBe(before.secondId);
       expect(after.firstId).toBe(before.firstId);
       expect(after.secondId).toBe(before.secondId);
-      expect(`${after.popupTop}:${after.popupLeft}`).not.toBe(
-        `${before.popupTop}:${before.popupLeft}`
-      );
+      expect(after.popupVisible).toBe(false);
     });
   });
 

--- a/src/content/ai-client.ts
+++ b/src/content/ai-client.ts
@@ -8,23 +8,14 @@ import {
   TONE_REWRITE_SCHEMA,
   buildProofreadInstruction,
   buildRewriteInstruction,
-  buildWarmupPrompt,
 } from "../shared/prompts";
-
-const WARMUP_MAX_CHARS = 1500;
 
 let aiInstance: ChromiumAIInstance | null = null;
 let testMode = false;
 type AISession = Awaited<ReturnType<typeof ChromiumAI.createSession>>;
 
 let dualBaseSessionPromise: Promise<AISession> | null = null;
-
-export type WarmClone = {
-  session: AISession;
-  warmup: Promise<void>;
-  text: string;
-  dispose: () => void;
-};
+let nextClonePromise: Promise<AISession> | null = null;
 
 function logSessionEvent(message: string): void {
   console.debug(`[WriteGooderer AI] ${message}`);
@@ -82,58 +73,56 @@ async function cloneDualSession(): Promise<AISession> {
   }
 }
 
+function refillClonePool(): void {
+  if (nextClonePromise) return;
+  nextClonePromise = cloneDualSession().catch((err) => {
+    logSessionEvent(`Clone pool refill failed: ${String(err)}`);
+    nextClonePromise = null;
+    throw err;
+  });
+}
+
+export async function takeClone(): Promise<AISession> {
+  if (nextClonePromise) {
+    const pending = nextClonePromise;
+    nextClonePromise = null;
+    try {
+      const session = await pending;
+      refillClonePool();
+      return session;
+    } catch {
+      // Fall through to a direct clone below.
+    }
+  }
+  const session = await cloneDualSession();
+  refillClonePool();
+  return session;
+}
+
 export async function prewarmSessions(): Promise<void> {
   if (testMode) return;
   logSessionEvent("Prewarming dual base session");
   await getDualBaseSessionPromise();
   logSessionEvent("Prewarmed dual base session");
+  refillClonePool();
 }
 
 export async function destroySessions(): Promise<void> {
   logSessionEvent("Destroying cached base session");
-  const result = await Promise.allSettled([dualBaseSessionPromise]);
+  const pending = [dualBaseSessionPromise, nextClonePromise];
+  dualBaseSessionPromise = null;
+  nextClonePromise = null;
+  const result = await Promise.allSettled(pending);
   for (const r of result) {
     if (r.status === "fulfilled" && r.value) {
-      r.value.destroy();
+      try {
+        r.value.destroy();
+      } catch (err) {
+        logSessionEvent(`Session destroy failed: ${String(err)}`);
+      }
     }
   }
-  dualBaseSessionPromise = null;
   logSessionEvent("Destroyed cached base session");
-}
-
-export function canWarmText(text: string): boolean {
-  if (testMode) return false;
-  const trimmed = text.trim();
-  return trimmed.length > 0 && trimmed.length <= WARMUP_MAX_CHARS;
-}
-
-export async function warmCloneForText(text: string): Promise<WarmClone> {
-  const session = await cloneDualSession();
-  let disposed = false;
-
-  const dispose = () => {
-    if (disposed) return;
-    disposed = true;
-    try {
-      session.destroy();
-      logSessionEvent("Disposed warm clone");
-    } catch (err) {
-      logSessionEvent(`Warm clone dispose failed: ${String(err)}`);
-    }
-  };
-
-  logSessionEvent("Warm clone: prompting paragraph");
-  const warmup = session
-    .prompt(buildWarmupPrompt(text))
-    .then(() => {
-      logSessionEvent("Warm clone: paragraph ingested");
-    })
-    .catch((err: unknown) => {
-      logSessionEvent(`Warm clone prompt failed: ${String(err)}`);
-      throw err;
-    });
-
-  return { session, warmup, text, dispose };
 }
 
 function mockProofread(text: string): ProofreadResult {
@@ -165,73 +154,47 @@ function mockRewrite(text: string, tone: string): RewriteResult {
   return { rewritten: `[${tone.toUpperCase()}] ${text}` };
 }
 
-export async function finalizeProofread(warm: WarmClone): Promise<ProofreadResult> {
+export async function proofread(
+  text: string,
+  opts: { signal?: AbortSignal } = {}
+): Promise<ProofreadResult> {
+  if (testMode) return mockProofread(text);
+  const session = await takeClone();
   try {
-    logSessionEvent("Finalize proofread: awaiting warmup");
-    await warm.warmup;
-    logSessionEvent("Finalize proofread: running instruction");
-    const raw = await warm.session.prompt(buildProofreadInstruction(), {
+    logSessionEvent("Proofread: running instruction");
+    const raw = await session.prompt(buildProofreadInstruction(text), {
       responseConstraint: PROOFREAD_SCHEMA,
-    });
+      signal: opts.signal,
+    } as any);
     return JSON.parse(raw) as ProofreadResult;
   } finally {
-    warm.dispose();
-  }
-}
-
-export async function finalizeRewrite(
-  warm: WarmClone,
-  tone: TonePreset
-): Promise<RewriteResult> {
-  try {
-    logSessionEvent("Finalize rewrite: awaiting warmup");
-    await warm.warmup;
-    logSessionEvent(`Finalize rewrite: running instruction for ${tone}`);
-    const raw = await warm.session.prompt(buildRewriteInstruction(tone), {
-      responseConstraint: TONE_REWRITE_SCHEMA,
-    });
-    return JSON.parse(raw) as RewriteResult;
-  } finally {
-    warm.dispose();
-  }
-}
-
-export async function proofread(text: string): Promise<ProofreadResult> {
-  if (testMode) return mockProofread(text);
-  try {
-    const warm = await warmCloneForText(text);
-    return await finalizeProofread(warm);
-  } catch (err) {
-    logSessionEvent(`Proofread wrapper failed, falling back: ${String(err)}`);
-    const session = await cloneDualSession();
     try {
-      const raw = await session.prompt(
-        `${buildWarmupPrompt(text)}\n\n${buildProofreadInstruction()}`,
-        { responseConstraint: PROOFREAD_SCHEMA }
-      );
-      return JSON.parse(raw) as ProofreadResult;
-    } finally {
       session.destroy();
+    } catch (err) {
+      logSessionEvent(`Proofread session destroy failed: ${String(err)}`);
     }
   }
 }
 
-export async function rewrite(text: string, tone: TonePreset): Promise<RewriteResult> {
+export async function rewrite(
+  text: string,
+  tone: TonePreset,
+  opts: { signal?: AbortSignal } = {}
+): Promise<RewriteResult> {
   if (testMode) return mockRewrite(text, tone);
+  const session = await takeClone();
   try {
-    const warm = await warmCloneForText(text);
-    return await finalizeRewrite(warm, tone);
-  } catch (err) {
-    logSessionEvent(`Rewrite wrapper failed, falling back: ${String(err)}`);
-    const session = await cloneDualSession();
+    logSessionEvent(`Rewrite: running instruction for ${tone}`);
+    const raw = await session.prompt(buildRewriteInstruction(tone, text), {
+      responseConstraint: TONE_REWRITE_SCHEMA,
+      signal: opts.signal,
+    } as any);
+    return JSON.parse(raw) as RewriteResult;
+  } finally {
     try {
-      const raw = await session.prompt(
-        `${buildWarmupPrompt(text)}\n\n${buildRewriteInstruction(tone)}`,
-        { responseConstraint: TONE_REWRITE_SCHEMA }
-      );
-      return JSON.parse(raw) as RewriteResult;
-    } finally {
       session.destroy();
+    } catch (err) {
+      logSessionEvent(`Rewrite session destroy failed: ${String(err)}`);
     }
   }
 }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -146,8 +146,8 @@ async function main() {
           icon.hideScore();
         }
 
-        if (popup.isVisible) {
-          popup.attachToField(field);
+        if (popup.isVisible && popup.currentField !== field) {
+          popup.hide();
         }
       } else if (!popup.isVisible) {
         icon.hide();

--- a/src/content/popup-card.ts
+++ b/src/content/popup-card.ts
@@ -1,18 +1,27 @@
-import {
-  canWarmText,
-  finalizeProofread,
-  finalizeRewrite,
-  proofread,
-  rewrite,
-  warmCloneForText,
-  type WarmClone,
-} from "./ai-client";
+import { proofread, rewrite } from "./ai-client";
 import { getTierForScore } from "../shared/constants";
-import type { TonePreset } from "../shared/types";
+import type { ProofreadResult, RewriteResult, TonePreset } from "../shared/types";
 import { ScoreDisplay } from "./score-display";
 import { LoadingState } from "./loading-state";
 import { DiffView } from "./diff-view";
 import { ToneSelector } from "./tone-selector";
+
+type SpeculativeIntent =
+  | { kind: "proofread" }
+  | { kind: "rewrite"; tone: TonePreset };
+
+type Speculative = {
+  intent: SpeculativeIntent;
+  text: string;
+  promise: Promise<ProofreadResult | RewriteResult>;
+  abort: AbortController;
+};
+
+function intentsEqual(a: SpeculativeIntent, b: SpeculativeIntent): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "rewrite" && b.kind === "rewrite") return a.tone === b.tone;
+  return true;
+}
 
 const POPUP_WIDTH = 520;
 const POPUP_MAX_HEIGHT = 520;
@@ -33,7 +42,7 @@ export class PopupCard {
 
   private activeField: HTMLElement | null = null;
   private repositionRAF: number | null = null;
-  private pendingWarm: WarmClone | null = null;
+  private speculative: Speculative | null = null;
   private onLoadingChange: (loading: boolean) => void;
   private onScoreReady: (field: HTMLElement, score: number, color: string) => void;
 
@@ -76,7 +85,10 @@ export class PopupCard {
     this.diffView.hide();
 
     // Tone selector (always mounted within the action surface)
-    this.toneSelector = new ToneSelector((tone) => this.handleToneSelect(tone));
+    this.toneSelector = new ToneSelector(
+      (tone) => this.handleToneSelect(tone),
+      (tone) => this.speculateFor({ kind: "rewrite", tone })
+    );
 
     // Rewrite result
     this.rewriteResult = document.createElement("div");
@@ -93,6 +105,9 @@ export class PopupCard {
     proofreadBtn.className = "wg-btn wg-btn-primary wg-proofread-btn";
     proofreadBtn.innerHTML = `<span class="wg-proofread-emoji">✨</span><span>Proofread</span>`;
     proofreadBtn.addEventListener("click", () => this.handleProofread());
+    proofreadBtn.addEventListener("pointerenter", () =>
+      this.speculateFor({ kind: "proofread" })
+    );
 
     const toneLabel = document.createElement("div");
     toneLabel.className = "wg-tone-label";
@@ -118,7 +133,6 @@ export class PopupCard {
     this.el.classList.add("wg-visible");
     this.attachToField(field);
     this.startTracking();
-    this.kickoffWarmup(field);
   }
 
   attachToField(field: HTMLElement): void {
@@ -126,7 +140,7 @@ export class PopupCard {
     this.activeField = field;
 
     if (changedField) {
-      this.disposePendingWarm();
+      this.abortSpeculative();
       this.resetContent();
     }
 
@@ -136,47 +150,65 @@ export class PopupCard {
   hide(): void {
     this.el.classList.remove("wg-visible");
     this.stopTracking();
-    this.disposePendingWarm();
+    this.abortSpeculative();
     this.resetContent();
   }
 
-  private disposePendingWarm(): void {
-    if (this.pendingWarm) {
-      this.pendingWarm.dispose();
-      this.pendingWarm = null;
+  private abortSpeculative(): void {
+    if (this.speculative) {
+      this.speculative.abort.abort();
+      // Keep a reference so awaiters still see the rejection; drop our handle.
+      this.speculative = null;
     }
   }
 
-  private kickoffWarmup(field: HTMLElement): void {
-    const text = this.getFieldText(field);
-    if (!canWarmText(text)) return;
-    this.disposePendingWarm();
-    warmCloneForText(text)
-      .then((warm) => {
-        if (this.activeField !== field || this.getFieldText(field) !== text) {
-          warm.dispose();
-          return;
-        }
-        this.pendingWarm = warm;
-      })
-      .catch(() => {
-        // swallow — finalize path will fall back to a fresh session
-      });
+  private speculateFor(intent: SpeculativeIntent): void {
+    const text = this.getFieldText();
+    if (!text.trim()) return;
+
+    // Already speculating on this exact intent+text — nothing to do.
+    if (
+      this.speculative &&
+      this.speculative.text === text &&
+      intentsEqual(this.speculative.intent, intent)
+    ) {
+      return;
+    }
+
+    this.abortSpeculative();
+
+    const abort = new AbortController();
+    const promise: Promise<ProofreadResult | RewriteResult> =
+      intent.kind === "proofread"
+        ? proofread(text, { signal: abort.signal })
+        : rewrite(text, intent.tone, { signal: abort.signal });
+
+    // Swallow unhandled-rejection noise for aborted speculations.
+    promise.catch(() => {});
+
+    this.speculative = { intent, text, promise, abort };
   }
 
-  private takeWarmFor(text: string): WarmClone | null {
-    const warm = this.pendingWarm;
-    if (!warm) return null;
-    if (warm.text !== text) {
-      this.disposePendingWarm();
+  private takeSpeculative(
+    intent: SpeculativeIntent,
+    text: string
+  ): Promise<ProofreadResult | RewriteResult> | null {
+    const s = this.speculative;
+    if (!s) return null;
+    if (s.text !== text || !intentsEqual(s.intent, intent)) {
+      this.abortSpeculative();
       return null;
     }
-    this.pendingWarm = null;
-    return warm;
+    this.speculative = null;
+    return s.promise;
   }
 
   get isVisible(): boolean {
     return this.el.classList.contains("wg-visible");
+  }
+
+  get currentField(): HTMLElement | null {
+    return this.activeField;
   }
 
   private position(): void {
@@ -267,8 +299,10 @@ export class PopupCard {
     this.rewriteResult.style.display = "none";
 
     try {
-      const warm = this.takeWarmFor(text);
-      const result = warm ? await finalizeProofread(warm) : await proofread(text);
+      const speculative = this.takeSpeculative({ kind: "proofread" }, text);
+      const result = (speculative
+        ? await speculative
+        : await proofread(text)) as ProofreadResult;
 
       const tier = getTierForScore(result.score);
       if (requestField) {
@@ -306,8 +340,10 @@ export class PopupCard {
     this.rewriteResult.style.display = "none";
 
     try {
-      const warm = this.takeWarmFor(text);
-      const result = warm ? await finalizeRewrite(warm, tone) : await rewrite(text, tone);
+      const speculative = this.takeSpeculative({ kind: "rewrite", tone }, text);
+      const result = (speculative
+        ? await speculative
+        : await rewrite(text, tone)) as RewriteResult;
 
       if (!requestField || this.activeField !== requestField) {
         return;

--- a/src/content/tone-selector.ts
+++ b/src/content/tone-selector.ts
@@ -6,10 +6,15 @@ export class ToneSelector {
   private el: HTMLElement;
   private selected: TonePreset = "professional";
   private onSelect: (tone: TonePreset) => void;
+  private onHover?: (tone: TonePreset) => void;
   private buttons: Map<TonePreset, HTMLElement> = new Map();
 
-  constructor(onSelect: (tone: TonePreset) => void) {
+  constructor(
+    onSelect: (tone: TonePreset) => void,
+    onHover?: (tone: TonePreset) => void
+  ) {
     this.onSelect = onSelect;
+    this.onHover = onHover;
 
     this.el = document.createElement("div");
     this.el.className = "wg-tone-selector";
@@ -23,6 +28,9 @@ export class ToneSelector {
       btn.className = "wg-tone-btn";
       btn.innerHTML = `<span class="wg-tone-emoji">${config.emoji}</span><span class="wg-tone-text"><span class="wg-tone-name">${config.name}</span><span class="wg-tone-sub">${config.subtitle}</span></span>`;
       btn.addEventListener("click", () => this.selectTone(tone));
+      if (this.onHover) {
+        btn.addEventListener("pointerenter", () => this.onHover?.(tone));
+      }
       grid.appendChild(btn);
       this.buttons.set(tone, btn);
     }

--- a/src/shared/__tests__/prompts.test.ts
+++ b/src/shared/__tests__/prompts.test.ts
@@ -1,29 +1,29 @@
 import { describe, it, expect } from "vitest";
 import {
-  buildTonePrompt,
-  PROOFREAD_INITIAL_PROMPTS,
+  DUAL_INITIAL_PROMPTS,
+  DUAL_SYSTEM_PROMPT,
   PROOFREAD_SCHEMA,
-  TONE_INITIAL_PROMPTS,
   TONE_REWRITE_SCHEMA,
+  buildProofreadInstruction,
+  buildRewriteInstruction,
 } from "../prompts";
 import type { TonePreset } from "../types";
 
-describe("buildTonePrompt", () => {
-  it("includes the tone name and description", () => {
-    const result = buildTonePrompt("Hello world", "professional");
+describe("buildProofreadInstruction", () => {
+  it("includes the user text", () => {
+    const result = buildProofreadInstruction("I has went to the stor.");
+    expect(result).toContain("I has went to the stor.");
+    expect(result.toLowerCase()).toContain("proofread");
+  });
+});
+
+describe("buildRewriteInstruction", () => {
+  it("includes the tone name, description, and user text", () => {
+    const text = "I got promoted at work today.";
+    const result = buildRewriteInstruction("professional", text);
     expect(result).toContain("Professional");
     expect(result).toContain("Formal, clear, and business-appropriate");
-  });
-
-  it("includes the user text", () => {
-    const text = "I got promoted at work today.";
-    const result = buildTonePrompt(text, "casual");
     expect(result).toContain(text);
-  });
-
-  it("formats as 'Tone: ... Text: ...'", () => {
-    const result = buildTonePrompt("test", "linkedin-influencer");
-    expect(result).toMatch(/^Tone: .+\n\nText: .+$/s);
   });
 
   it("works for all tone presets", () => {
@@ -38,31 +38,69 @@ describe("buildTonePrompt", () => {
       "corporate-buzzword",
     ];
     for (const tone of tones) {
-      const result = buildTonePrompt("test text", tone);
-      expect(result).toContain("Tone:");
+      const result = buildRewriteInstruction(tone, "test text");
       expect(result).toContain("test text");
     }
   });
 });
 
-describe("PROOFREAD_INITIAL_PROMPTS", () => {
-  it("starts with a system message", () => {
-    expect(PROOFREAD_INITIAL_PROMPTS[0].role).toBe("system");
+describe("DUAL_INITIAL_PROMPTS", () => {
+  it("starts with the dual system message", () => {
+    expect(DUAL_INITIAL_PROMPTS[0].role).toBe("system");
+    expect(DUAL_INITIAL_PROMPTS[0].content).toBe(DUAL_SYSTEM_PROMPT);
   });
 
-  it("has a user/assistant few-shot pair", () => {
-    expect(PROOFREAD_INITIAL_PROMPTS[1].role).toBe("user");
-    expect(PROOFREAD_INITIAL_PROMPTS[2].role).toBe("assistant");
+  it("contains single-turn instruction → JSON pairs (no intermediate READY)", () => {
+    for (const entry of DUAL_INITIAL_PROMPTS) {
+      expect(entry.content).not.toBe("READY");
+    }
   });
 
-  it("the assistant response is valid JSON matching the schema", () => {
-    const parsed = JSON.parse(PROOFREAD_INITIAL_PROMPTS[2].content);
+  it("each user turn carries both an instruction and the paragraph inline", () => {
+    const userTurns = DUAL_INITIAL_PROMPTS.filter((p) => p.role === "user");
+    expect(userTurns.length).toBeGreaterThan(0);
+    for (const turn of userTurns) {
+      expect(turn.content.length).toBeGreaterThan(20);
+      // Must not be a bare "Paragraph: ..." prompt (the pattern that caused
+      // the warmup to complete into a full JSON response).
+      expect(turn.content.startsWith("Paragraph:")).toBe(false);
+    }
+  });
+
+  it("proofread few-shot assistant response parses into a valid result shape", () => {
+    const proofreadAssistant = DUAL_INITIAL_PROMPTS.find(
+      (p, i) =>
+        p.role === "assistant" &&
+        DUAL_INITIAL_PROMPTS[i - 1]?.role === "user" &&
+        DUAL_INITIAL_PROMPTS[i - 1]?.content.toLowerCase().includes("proofread")
+    );
+    expect(proofreadAssistant).toBeDefined();
+    const parsed = JSON.parse(proofreadAssistant!.content);
     expect(parsed).toHaveProperty("corrected");
     expect(parsed).toHaveProperty("changes");
     expect(parsed).toHaveProperty("score");
     expect(parsed).toHaveProperty("tier");
     expect(Array.isArray(parsed.changes)).toBe(true);
     expect(typeof parsed.score).toBe("number");
+  });
+
+  it("rewrite few-shot assistant response parses into a valid result shape", () => {
+    const rewriteAssistant = DUAL_INITIAL_PROMPTS.find(
+      (p, i) =>
+        p.role === "assistant" &&
+        DUAL_INITIAL_PROMPTS[i - 1]?.role === "user" &&
+        DUAL_INITIAL_PROMPTS[i - 1]?.content.toLowerCase().includes("rewrite")
+    );
+    expect(rewriteAssistant).toBeDefined();
+    const parsed = JSON.parse(rewriteAssistant!.content);
+    expect(parsed).toHaveProperty("rewritten");
+    expect(typeof parsed.rewritten).toBe("string");
+  });
+});
+
+describe("DUAL_SYSTEM_PROMPT", () => {
+  it("does not mention the retired READY protocol", () => {
+    expect(DUAL_SYSTEM_PROMPT).not.toMatch(/READY/);
   });
 });
 
@@ -85,18 +123,6 @@ describe("PROOFREAD_SCHEMA", () => {
     expect(tierSchema.enum).toContain("Caveman");
     expect(tierSchema.enum).toContain("WriteGooderer");
     expect(tierSchema.enum).toHaveLength(6);
-  });
-});
-
-describe("TONE_INITIAL_PROMPTS", () => {
-  it("starts with a system message", () => {
-    expect(TONE_INITIAL_PROMPTS[0].role).toBe("system");
-  });
-
-  it("the assistant response is valid JSON with a rewritten field", () => {
-    const parsed = JSON.parse(TONE_INITIAL_PROMPTS[2].content);
-    expect(parsed).toHaveProperty("rewritten");
-    expect(typeof parsed.rewritten).toBe("string");
   });
 });
 

--- a/src/shared/prompts.ts
+++ b/src/shared/prompts.ts
@@ -1,43 +1,6 @@
 import { TONES } from "./constants";
 import type { TonePreset } from "./types";
 
-export const PROOFREAD_SYSTEM_PROMPT =
-  "You are WriteGooderer, a writing assistant. Proofread text for grammar, spelling, punctuation, and clarity. Return corrections, a quality score from 0 to 100, and the matching tier name. Be honest with scoring - perfect text should score 90+, minor issues 60-80, significant issues below 50.";
-
-export const PROOFREAD_INITIAL_PROMPTS: (
-  | { role: "system"; content: string }
-  | { role: "user"; content: string }
-  | { role: "assistant"; content: string }
-)[] = [
-  { role: "system", content: PROOFREAD_SYSTEM_PROMPT },
-  {
-    role: "user",
-    content: "I has went to the stor yesterday and buyed some mik.",
-  },
-  {
-    role: "assistant",
-    content: JSON.stringify({
-      corrected: "I went to the store yesterday and bought some milk.",
-      changes: [
-        {
-          original: "has went",
-          replacement: "went",
-          reason: "Incorrect auxiliary verb",
-        },
-        { original: "stor", replacement: "store", reason: "Spelling" },
-        {
-          original: "buyed",
-          replacement: "bought",
-          reason: "Irregular past tense",
-        },
-        { original: "mik", replacement: "milk", reason: "Spelling" },
-      ],
-      score: 18,
-      tier: "Caveman",
-    }),
-  },
-];
-
 export const PROOFREAD_SCHEMA = {
   type: "object",
   properties: {
@@ -70,29 +33,6 @@ export const PROOFREAD_SCHEMA = {
   required: ["corrected", "changes", "score", "tier"],
 };
 
-export const TONE_SYSTEM_PROMPT =
-  "You are WriteGooderer. Rewrite text in the specified tone while preserving the core meaning. Be creative and fully commit to the tone.";
-
-export const TONE_INITIAL_PROMPTS: (
-  | { role: "system"; content: string }
-  | { role: "user"; content: string }
-  | { role: "assistant"; content: string }
-)[] = [
-  { role: "system", content: TONE_SYSTEM_PROMPT },
-  {
-    role: "user",
-    content:
-      "Tone: LinkedIn Influencer\n\nText: I got promoted at work today.",
-  },
-  {
-    role: "assistant",
-    content: JSON.stringify({
-      rewritten:
-        "I'm thrilled to announce that after years of dedication, countless late nights, and unwavering belief in myself...\n\nI got a promotion.\n\nBut this isn't about the title. It's about the JOURNEY.\n\nHere are 3 lessons I learned along the way:\n\n1. Show up every day\n2. Be authentic\n3. Never stop grinding\n\nAgree? \u{1F447}",
-    }),
-  },
-];
-
 export const TONE_REWRITE_SCHEMA = {
   type: "object",
   properties: {
@@ -101,13 +41,8 @@ export const TONE_REWRITE_SCHEMA = {
   required: ["rewritten"],
 };
 
-export function buildTonePrompt(text: string, tone: TonePreset): string {
-  const config = TONES[tone];
-  return `Tone: ${config.name} (${config.description})\n\nText: ${text}`;
-}
-
 export const DUAL_SYSTEM_PROMPT =
-  "You are WriteGooderer. You handle two tasks on user text: (a) proofread — return corrections, a 0-100 quality score, and a tier name; (b) rewrite in a specified tone — preserve meaning, commit fully to the tone. The user will first share a paragraph; acknowledge briefly with the single word READY and wait. When the user then asks you to proofread or rewrite, respond only with JSON matching the requested schema. Honest scoring: perfect text 90+, minor issues 60-80, significant issues below 50.";
+  "You are WriteGooderer. You handle two tasks on user text: (a) proofread — return corrections, a 0-100 quality score, and a tier name; (b) rewrite in a specified tone — preserve meaning, commit fully to the tone. Respond only with JSON matching the requested schema. Honest scoring: perfect text 90+, minor issues 60-80, significant issues below 50.";
 
 export const DUAL_INITIAL_PROMPTS: (
   | { role: "system"; content: string }
@@ -118,12 +53,7 @@ export const DUAL_INITIAL_PROMPTS: (
   {
     role: "user",
     content:
-      "Paragraph:\n\nI has went to the stor yesterday and buyed some mik.",
-  },
-  { role: "assistant", content: "READY" },
-  {
-    role: "user",
-    content: "Now proofread the paragraph above.",
+      "Proofread this paragraph:\n\nI has went to the stor yesterday and buyed some mik.",
   },
   {
     role: "assistant",
@@ -149,13 +79,8 @@ export const DUAL_INITIAL_PROMPTS: (
   },
   {
     role: "user",
-    content: "Paragraph:\n\nI got promoted at work today.",
-  },
-  { role: "assistant", content: "READY" },
-  {
-    role: "user",
     content:
-      "Now rewrite the paragraph above in this tone: LinkedIn Influencer (performative self-help hustle energy).",
+      "Rewrite this paragraph in this tone: LinkedIn Influencer (performative self-help hustle energy).\n\nParagraph:\n\nI got promoted at work today.",
   },
   {
     role: "assistant",
@@ -166,15 +91,11 @@ export const DUAL_INITIAL_PROMPTS: (
   },
 ];
 
-export function buildWarmupPrompt(text: string): string {
-  return `Paragraph:\n\n${text}`;
+export function buildProofreadInstruction(text: string): string {
+  return `Proofread this paragraph:\n\n${text}`;
 }
 
-export function buildProofreadInstruction(): string {
-  return "Now proofread the paragraph above.";
-}
-
-export function buildRewriteInstruction(tone: TonePreset): string {
+export function buildRewriteInstruction(tone: TonePreset, text: string): string {
   const config = TONES[tone];
-  return `Now rewrite the paragraph above in this tone: ${config.name} (${config.description}).`;
+  return `Rewrite this paragraph in this tone: ${config.name} (${config.description}).\n\nParagraph:\n\n${text}`;
 }


### PR DESCRIPTION
The speculative warmup from b05cbf2 sent a bare "Paragraph: ..." prompt to a cloned session. Because the few-shot examples taught the model a Paragraph -> READY -> instruction -> JSON pattern, the warmup would pattern-complete past READY into a full JSON response, wasting tokens and polluting the KV cache.

- Restructure few-shots to single-turn (instruction + paragraph in one user message -> JSON in one assistant message). No READY turn, no completable pattern for a bare-paragraph prompt.
- Update DUAL_SYSTEM_PROMPT to drop the retired READY protocol.
- Change buildProofreadInstruction / buildRewriteInstruction signatures to take the paragraph text and return a complete user message.
- Delete dead single-task exports (PROOFREAD_INITIAL_PROMPTS, TONE_INITIAL_PROMPTS, buildTonePrompt, etc.) that only their own tests referenced.

Swap warmup for two lighter speculation mechanisms:

- Size-1 clone pool in ai-client.ts: takeClone() hands out a pre-warmed clone and refills in the background. proofread / rewrite now accept an AbortSignal.
- Hover-speculate in popup-card.ts: pointerenter on the Proofread button or a tone button kicks off the real call. On click, await the speculative promise if it matches; otherwise start fresh. Aborts on popup hide, field change, or a different hover.

Also fix a UI bug: the popup used to reposition to a newly focused text field. It now hides instead, matching user expectation.