### PR TITLE
Speculate on pointerdown instead of pointerenter

### DIFF
--- a/src/content/popup-card.ts
+++ b/src/content/popup-card.ts
@@ -105,7 +105,7 @@ export class PopupCard {
     proofreadBtn.className = "wg-btn wg-btn-primary wg-proofread-btn";
     proofreadBtn.innerHTML = `<span class="wg-proofread-emoji">✨</span><span>Proofread</span>`;
     proofreadBtn.addEventListener("click", () => this.handleProofread());
-    proofreadBtn.addEventListener("pointerenter", () =>
+    proofreadBtn.addEventListener("pointerdown", () =>
       this.speculateFor({ kind: "proofread" })
     );
 

--- a/src/content/tone-selector.ts
+++ b/src/content/tone-selector.ts
@@ -6,15 +6,15 @@ export class ToneSelector {
   private el: HTMLElement;
   private selected: TonePreset = "professional";
   private onSelect: (tone: TonePreset) => void;
-  private onHover?: (tone: TonePreset) => void;
+  private onArm?: (tone: TonePreset) => void;
   private buttons: Map<TonePreset, HTMLElement> = new Map();
 
   constructor(
     onSelect: (tone: TonePreset) => void,
-    onHover?: (tone: TonePreset) => void
+    onArm?: (tone: TonePreset) => void
   ) {
     this.onSelect = onSelect;
-    this.onHover = onHover;
+    this.onArm = onArm;
 
     this.el = document.createElement("div");
     this.el.className = "wg-tone-selector";
@@ -28,8 +28,8 @@ export class ToneSelector {
       btn.className = "wg-tone-btn";
       btn.innerHTML = `<span class="wg-tone-emoji">${config.emoji}</span><span class="wg-tone-text"><span class="wg-tone-name">${config.name}</span><span class="wg-tone-sub">${config.subtitle}</span></span>`;
       btn.addEventListener("click", () => this.selectTone(tone));
-      if (this.onHover) {
-        btn.addEventListener("pointerenter", () => this.onHover?.(tone));
+      if (this.onArm) {
+        btn.addEventListener("pointerdown", () => this.onArm?.(tone));
       }
       grid.appendChild(btn);
       this.buttons.set(tone, btn);


### PR DESCRIPTION
The hover-speculate introduced in PR #8 burned a fresh on-device session on every pointerenter, even when the user was just sweeping across the tone grid. The on-device-internals event log showed 6+ "Starting on-device session" events in under a second during a single mouse sweep. Each aborted speculation still paid the session-creation cost on the model service side.

Switch both the Proofread button and the tone buttons to fire speculation on pointerdown. Pointerdown is a deterministic commitment signal: exactly one session per button actually pressed, never per mouse transit. We lose ~100-300ms of head-start vs hover, but on a 2-8s model call that's 2-5% of total latency — well worth the predictability and the compute saved on aborted speculations.

Clone pool and speculation machinery unchanged.