### PR TITLE
Speculate proofread on popup-open

### DIFF
--- a/src/content/popup-card.ts
+++ b/src/content/popup-card.ts
@@ -132,6 +132,7 @@ export class PopupCard {
     this.resetContent();
     this.el.classList.add("wg-visible");
     this.attachToField(field);
+    this.speculateFor({ kind: "proofread" });
     this.startTracking();
   }
 


### PR DESCRIPTION
## Summary

- When the popup opens with non-empty text, immediately fire a speculative `proofread()` instead of waiting for the Proofread button's `pointerdown`.
- Hides the entire hover/read/decide latency for the common case (proofread is the primary CTA and dominant intent).

## Why

Today, speculation only fires on `pointerdown` of the Proofread button or a tone chip. The popup is often visible for a second or more before the user clicks — that idle window was wasted. Proofread is overwhelmingly the most likely action, so eagerly speculating it pays off.

## Tone path stays correct

The existing abort plumbing handles the proofread→tone switch with no changes:

1. Tone `pointerdown` → `speculateFor({ kind: "rewrite", tone })`.
2. `intentsEqual` returns false → `abortSpeculative()` aborts the in-flight proofread via its `AbortSignal`.
3. `proofread()`'s `finally` block destroys the aborted session — no leak.
4. Fresh rewrite speculation runs on a new clone; tone click consumes it via `takeSpeculative`.

The Proofread button's own `pointerdown` handler becomes a harmless dedupe (early-return on same intent+text).

## Cost

A tone-switch-after-popup-open consumes two clones (aborted proofread + rewrite) instead of one. The clone pool refills async, and on-device prefill/generation is cheap. Negligible.

## Test plan

- [x] `npm run test` (56/56 pass)
- [ ] Open popup on a page with text in a focused field — verify `[WriteGooderer AI] Proofread: running instruction` logs at popup-open, not at button pointerdown
- [ ] Click a tone chip before proofread completes — proofread aborts cleanly, rewrite completes, no UI flash
- [ ] Edit text after popup opens, then click Proofread — fresh request fires (stale speculation discarded by `text !== s.text` guard)
- [ ] Open popup with empty field — no speculation fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)