### PR TITLE
Tighten landing page copy and reduce em dash use

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -6,12 +6,12 @@
     <title>WriteGooderer — A private writing assistant for Chrome</title>
     <meta
       name="description"
-      content="A private writing assistant for Chrome. Proofread, rewrite, and tone-shift in any text field — powered by Chrome's on-device Gemini Nano, so nothing you type leaves the browser."
+      content="Proofread, rewrite, and shift tone in any text field. Runs on Chrome's on-device Gemini Nano, so nothing you type leaves the browser."
     />
     <meta property="og:title" content="WriteGooderer — A private writing assistant for Chrome" />
     <meta
       property="og:description"
-      content="Proofread, rewrite, and tone-shift in any text field. Runs on Chrome's on-device Gemini Nano — nothing you type leaves the browser."
+      content="Proofread, rewrite, and shift tone in any text field. Runs on Chrome's on-device Gemini Nano. Nothing you type leaves the browser."
     />
     <meta property="og:image" content="assets/screenshot.png" />
     <meta name="theme-color" content="#ff7a3e" />
@@ -46,16 +46,15 @@
     <main id="top">
       <section class="hero">
         <div class="hero-copy">
-          <p class="eyebrow">A Chrome extension</p>
+          <p class="eyebrow">Now hiring: Gemini Nano</p>
           <h1>
             Makes your writing
             <span class="grad">gooderer</span>.
           </h1>
           <p class="lede">
-            A private writing assistant that puts Chrome's on-device Gemini
-            Nano to use. Proofread, rewrite, and tone-shift in any text field
-            on the web — all on your own machine, so nothing you type is
-            uploaded, logged, or used to train a model.
+            Proofread, rewrite, and shift tone in any text field. Runs on
+            Chrome's on-device Gemini Nano, so nothing you type leaves the
+            browser.
           </p>
           <div class="cta-row">
             <a
@@ -116,7 +115,7 @@
           <h3>Private by default</h3>
           <p>
             Every keystroke stays on-device. No accounts, no servers, no
-            telemetry — just Chrome's built-in Gemini Nano, doing the work
+            telemetry. Just Chrome's built-in Gemini Nano, doing the work
             locally.
           </p>
         </article>
@@ -133,7 +132,7 @@
           <h3>Sound how you want</h3>
           <p>
             Switch between Professional, Friendly, LinkedIn Influencer, and
-            Passive Aggressive in one click. Same point — different voice.
+            Passive Aggressive in one click. Same point, different voice.
           </p>
         </article>
       </section>


### PR DESCRIPTION
## Summary

- Trim the hero lede from a single 41-word, em-dashed sentence into two short sentences with no em dash.
- Swap the `A Chrome extension` eyebrow for `Now hiring: Gemini Nano` so it primes the why-section's job framing instead of restating the obvious.
- Remove in-prose em dashes from the privacy and tone feature pills and from the meta/OG descriptions; keep em dashes only in idiomatic title separators and the JS-replaced star-count placeholders.

## Test plan

- [ ] Open `site/index.html` locally (or the GitHub Pages deploy preview) and confirm the hero, eyebrow, feature pills, why-section, and star CTA all render correctly.
- [ ] Spot-check the page on mobile width (≤720px) — the hero stack and feature pills should reflow as before.
- [ ] Confirm the live star count still loads in the topbar pill, hero button, and bottom star CTA.
- [ ] View the page source and confirm the `<title>` and `og:title` separators are the only remaining em dashes in prose-adjacent positions; star-count `—` placeholders are intentional and get replaced by JS.

https://claude.ai/code/session_01TndGFP1LZGZtddKBwPEMXT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TndGFP1LZGZtddKBwPEMXT)_