### PR TITLE
Tone down homepage copy to deadpan

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -85,8 +85,8 @@
           />
         </figure>
         <p class="works-on">
-          Works in Gmail, Slack, Notion, GitHub, LinkedIn, and everywhere else
-          you type things you later regret.
+          Works in Gmail, Slack, Notion, GitHub, LinkedIn, and the rest of the
+          textareas you live in.
         </p>
       </section>
 
@@ -98,40 +98,38 @@
         <p class="why-body">
           Out of the box, Chrome's on-device Gemini Nano mostly powers
           <em>Help me write</em> in the omnibox. For most of us, that's a 4GB
-          roommate who doesn't pay rent. WriteGooderer points the same model at
-          every other text field on the web, so the AI already on your disk
-          finally earns its disk space.
+          model sitting on disk doing nothing. WriteGooderer points it at
+          every other text field on the web, so it has actual work to do.
         </p>
       </section>
 
       <section class="features" aria-label="Features">
         <div class="section-head">
           <p class="eyebrow">What it does</p>
-          <h2>Small extension. Strong opinions about your commas.</h2>
+          <h2>Proofread, rewrite, change tone.</h2>
         </div>
         <div class="feature-grid">
           <article class="feature">
             <h3>Private by default</h3>
             <p>
               Every keystroke stays on-device. No accounts, no servers, no
-              telemetry. The only thing judging your grammar is your own
-              laptop.
+              telemetry. Just Chrome's built-in Gemini Nano, doing the work
+              locally.
             </p>
           </article>
           <article class="feature">
             <h3>Edit before you commit</h3>
             <p>
               A side-by-side diff shows every fix before it touches your draft.
-              Apply the whole rewrite, or keep the typos you're emotionally
-              attached to.
+              Apply the whole rewrite, or only the changes you actually want.
             </p>
           </article>
           <article class="feature">
             <h3>Zero context-switching</h3>
             <p>
               Click into any text field and a small floating <code>W</code>
-              appears beside it. No copy-pasting your draft into another tab
-              like it's 2019.
+              appears beside it. No copying your draft into another tab and
+              back.
             </p>
           </article>
         </div>
@@ -142,8 +140,8 @@
           <p class="eyebrow">The Gooderness score</p>
           <h2>Every proofread comes with a grade.</h2>
           <p class="section-lede">
-            Zero to one hundred, with a tier you'll either screenshot or never
-            speak of again.
+            A score from 0 to 100, and one of six tiers. Most drafts land
+            somewhere in the middle.
           </p>
         </div>
         <ol class="tiers">
@@ -223,14 +221,14 @@
       <section class="how" aria-label="How it works">
         <div class="section-head">
           <p class="eyebrow">How it works</p>
-          <h2>Three clicks, start to gooderer.</h2>
+          <h2>Three clicks, no new tabs.</h2>
         </div>
         <ol class="steps">
           <li>
             <span class="step-num">1</span>
             <div>
               <h3>Click into a text field</h3>
-              <p>A small floating <code>W</code> appears beside it, minding its own business until you need it.</p>
+              <p>A small floating <code>W</code> appears beside it. It stays out of the way until you click it.</p>
             </div>
           </li>
           <li>
@@ -244,7 +242,7 @@
             <span class="step-num">3</span>
             <div>
               <h3>Apply what you like</h3>
-              <p>Skim the diff, then send the edits straight back into your draft. No copy-paste round trip.</p>
+              <p>Skim the diff, then send the edits straight back into your draft.</p>
             </div>
           </li>
         </ol>


### PR DESCRIPTION
Follow-up to #37. The redesigned homepage had a joke appended to nearly every sentence, which reads as AI-generated filler. This pass strips the copy back to deadpan and lets the product's own absurdity — the name, the Gooderness tiers, the tone presets — carry the humor.

## Changes

- **Features**: "Small extension. Strong opinions about your commas." becomes the plain "Proofread, rewrite, change tone." Card copy drops "typos you're emotionally attached to", "the only thing judging your grammar is your own laptop", and "like it's 2019" in favor of the original factual phrasing.
- **Why section**: "4GB roommate who doesn't pay rent" / "finally earns its disk space" reverts to the straighter "a 4GB model sitting on disk doing nothing... so it has actual work to do."
- **Gooderness score lede**: "a tier you'll either screenshot or never speak of again" becomes "one of six tiers. Most drafts land somewhere in the middle."
- **How it works**: "Three clicks, start to gooderer." becomes "Three clicks, no new tabs." and the step copy loses its punchlines.
- **Screenshot caption**: restores "the rest of the textareas you live in."

Kept: the ~~better~~ *gooderer* hero strikethrough, "Now hiring: Gemini Nano", the tier ladder, the four tone-rewrite examples, and the footer's rotating loading quips (which come from the extension's real quip list).

HTML copy changes only; no CSS or layout changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpmXhBxMKchuWTJVznPNzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpmXhBxMKchuWTJVznPNzp)_